### PR TITLE
feat: verify that there are no snapshot dependencies before release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,8 @@ runs:
                 # referenceActions: null
           - "@semantic-release/changelog"
           - - "@semantic-release/exec"
-            - publishCmd: RELEASE=true ./gradlew showVersion verifyReleaseVersion \$PUBLISH_TASKS
+            - verifyReleaseCmd: ./gradlew verifyNoSnapshotDependencies
+              publishCmd: RELEASE=true ./gradlew showVersion verifyReleaseVersion \$PUBLISH_TASKS
           - - "@semantic-release/git"
             - assets:
                 - CHANGELOG.md


### PR DESCRIPTION
BREAKING CHANGE: requires at least version 2.1.0 of Gradle semantic release version plugin